### PR TITLE
Fast test login

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,36 @@ For test purpose there mock helper sign_in(user)
 
 - add `require "keycloak_ruby/testing/keycloak_helpers"` to keycloak_helper.rb
 - add sign_in in tests `config.include KeycloakRuby::Testing::KeycloakHelpers`
+
+### Fast test login
+
+По умолчанию `sign_in` в браузерных тестах (`:feature` / `:system`) проходит полный цикл через OmniAuth.
+Чтобы ускорить тесты, можно включить быстрый логин через Rack-middleware — он записывает фейковые токены
+прямо в сессию, минуя OmniAuth и Keycloak.
+
+Добавьте в `config/keycloak.yml`:
+
+```yaml
+test:
+  fast_test_login: true
+  # ... остальные параметры
+```
+
+После этого `sign_in(user)` в feature/system тестах будет использовать middleware вместо полного входа.
+
+Если в отдельном тесте нужно проверить сам логин (flash-сообщения, редиректы и т.д.),
+используйте `full_sign_in(user)` — он всегда проходит полный цикл через OmniAuth.
+
+```ruby
+# Большинство тестов — быстрый вход (при fast_test_login: true)
+sign_in(user)
+
+# Тесты, проверяющие логин
+full_sign_in(user)
+```
+
+| Тип теста | `sign_in` (fast_test_login: true) | `sign_in` (fast_test_login: false) | `full_sign_in` |
+|---|---|---|---|
+| `:feature` / `:system` | Middleware — сессия напрямую | OmniAuth mock → visit /login → клик | OmniAuth mock → visit /login → клик |
+| `:request` | `mock_token_service` | `mock_token_service` | `mock_token_service` |
+| `:controller` и др. | `mock_token_service` | `mock_token_service` | `mock_keycloak_login` без Capybara |

--- a/lib/keycloak_ruby.rb
+++ b/lib/keycloak_ruby.rb
@@ -11,7 +11,8 @@ require "omniauth/rails_csrf_protection/railtie" if defined?(Rails)
 loader = Zeitwerk::Loader.for_gem
 loader.ignore(
   "#{__dir__}/generators",
-  "#{__dir__}/templates"
+  "#{__dir__}/templates",
+  "#{__dir__}/keycloak_ruby/railtie.rb"
 )
 loader.setup
 

--- a/lib/keycloak_ruby.rb
+++ b/lib/keycloak_ruby.rb
@@ -16,6 +16,7 @@ loader.ignore(
 loader.setup
 
 require "generators/keycloak_ruby/install_generator" if defined?(Rails)
+require "keycloak_ruby/railtie" if defined?(Rails::Railtie)
 
 # Module for interacting with Keycloak
 module KeycloakRuby

--- a/lib/keycloak_ruby/config.rb
+++ b/lib/keycloak_ruby/config.rb
@@ -50,7 +50,8 @@ module KeycloakRuby
                   :admin_client_id,
                   :admin_client_secret,
                   :oauth_client_id,
-                  :oauth_client_secret
+                  :oauth_client_secret,
+                  :fast_test_login
 
     attr_reader :config_path
 

--- a/lib/keycloak_ruby/railtie.rb
+++ b/lib/keycloak_ruby/railtie.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module KeycloakRuby
+  # Подключает middleware для быстрого логина в тестах
+  class Railtie < ::Rails::Railtie
+    initializer "keycloak_ruby.test_login_middleware" do |app|
+      if Rails.env.test?
+        require "keycloak_ruby/testing/login_middleware"
+        app.middleware.insert_before ActionDispatch::Flash, KeycloakRuby::Testing::LoginMiddleware
+      end
+    end
+  end
+end

--- a/lib/keycloak_ruby/railtie.rb
+++ b/lib/keycloak_ruby/railtie.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 module KeycloakRuby
-  # Подключает middleware для быстрого логина в тестах
+  # Подключает middleware для быстрого логина в тестах.
+  # Включается только если в конфиге стоит fast_test_login: true
   class Railtie < ::Rails::Railtie
     initializer "keycloak_ruby.test_login_middleware" do |app|
-      if Rails.env.test?
+      if Rails.env.test? && KeycloakRuby.config.fast_test_login
         require "keycloak_ruby/testing/login_middleware"
         app.middleware.insert_before ActionDispatch::Flash, KeycloakRuby::Testing::LoginMiddleware
       end

--- a/lib/keycloak_ruby/testing/keycloak_helpers.rb
+++ b/lib/keycloak_ruby/testing/keycloak_helpers.rb
@@ -6,13 +6,14 @@ module KeycloakRuby
   module Testing
     # Хелперы для тестов с Keycloak
     module KeycloakHelpers
-      # Быстрый вход: для браузерных тестов (:feature/:system) устанавливает сессию
-      # через middleware без прохождения OmniAuth. Для остальных — мокирует TokenService.
-      # Если нужна полная процедура входа, используйте full_sign_in.
+      # Быстрый вход: если включён fast_test_login, для браузерных тестов
+      # устанавливает сессию через middleware без OmniAuth.
+      # Если флаг выключен — идёт через полный логин.
+      # Для остальных типов тестов — мокирует TokenService.
       def sign_in(user, test_type: auto_detect_test_type)
         case test_type
         when :feature, :system
-          visit "/__test_login__/#{user.id}"
+          fast_login_enabled? ? visit("/__test_login__/#{user.id}") : full_sign_in(user, test_type:)
         else
           mock_token_service(user)
         end
@@ -119,6 +120,10 @@ module KeycloakRuby
         else
           :feature
         end
+      end
+
+      def fast_login_enabled?
+        KeycloakRuby.config.fast_test_login
       end
     end
   end

--- a/lib/keycloak_ruby/testing/keycloak_helpers.rb
+++ b/lib/keycloak_ruby/testing/keycloak_helpers.rb
@@ -4,16 +4,29 @@
 # :reek:UtilityFunction :reek:ControlParameter :reek:ManualDispatch :reek:BooleanParameter :reek:LongParameterList
 module KeycloakRuby
   module Testing
-    # Helper module for tests with Keycloak
+    # Хелперы для тестов с Keycloak
     module KeycloakHelpers
-      # Combines both sign-in approaches with automatic detection of test type
+      # Быстрый вход: для браузерных тестов (:feature/:system) устанавливает сессию
+      # через middleware без прохождения OmniAuth. Для остальных — мокирует TokenService.
+      # Если нужна полная процедура входа, используйте full_sign_in.
       def sign_in(user, test_type: auto_detect_test_type)
+        case test_type
+        when :feature, :system
+          visit "/__test_login__/#{user.id}"
+        else
+          mock_token_service(user)
+        end
+      end
+
+      # Полная процедура входа через OmniAuth для тестов, которые проверяют сам логин.
+      # Проходит /login → OmniAuth callback → SessionsController#create.
+      def full_sign_in(user, test_type: auto_detect_test_type)
         case test_type
         when :request
           mock_token_service(user)
         when :feature, :system
           mock_keycloak_login(user, use_capybara: true)
-        else # :controller, :view, etc.
+        else
           mock_keycloak_login(user, use_capybara: false)
         end
       end
@@ -31,9 +44,9 @@ module KeycloakRuby
         user_data
       end
 
-      # Delete all users from Keycloak
+      # Удаление всех пользователей из Keycloak
       def self.delete_all_keycloak_users
-        users = KeycloakRuby::User.find("") # Empty search string to find all users
+        users = KeycloakRuby::User.find("") # Пустая строка — ищем всех
         users.each do |user|
           KeycloakRuby::User.delete_by_id(user["id"])
         end
@@ -110,14 +123,14 @@ module KeycloakRuby
     end
   end
 end
-# Automatically include in common test frameworks
+# Автоматическое подключение хелперов в тестовые фреймворки
 if defined?(RSpec)
   RSpec.configure do |config|
     config.include KeycloakRuby::Testing::KeycloakHelpers
   end
 elsif defined?(Minitest)
   module Minitest
-    # Include helpers in minitest module
+    # Подключение хелперов в Minitest
     class Test
       include KeycloakRuby::Testing::KeycloakHelpers
     end

--- a/lib/keycloak_ruby/testing/login_middleware.rb
+++ b/lib/keycloak_ruby/testing/login_middleware.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module KeycloakRuby
+  module Testing
+    # Rack-middleware для быстрой аутентификации в тестах.
+    # Записывает токены в сессию напрямую, минуя OmniAuth и Keycloak.
+    #
+    # Подключается автоматически в test-окружении через KeycloakRuby::Railtie.
+    # Используется хелпером sign_in для браузерных тестов (:feature/:system).
+    #
+    # Было:  visit /login → рендер HTML → клик → OmniAuth → SessionsController → редирект
+    # Стало: visit /__test_login__/123 → запись сессии → 204 No Content
+    class LoginMiddleware
+      TEST_LOGIN_PATH = %r{\A/__test_login__/(\d+)\z}
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        if (match = env["PATH_INFO"].match(TEST_LOGIN_PATH))
+          handle_test_login(env, match[1].to_i)
+        else
+          @app.call(env)
+        end
+      end
+
+      private
+
+      def handle_test_login(env, user_id)
+        user = ::User.find(user_id)
+        email = user.email
+        expired_time = 2.hours.from_now.to_i
+        token_payload = { "email" => email, "exp" => expired_time }
+
+        session = env["rack.session"]
+        session[:access_token] = JWT.encode(token_payload, nil, "none")
+        session[:refresh_token] = "fake-refresh-#{email}"
+        session[:id_token] = "fake-id-#{email}"
+
+        [204, {}, []]
+      end
+    end
+  end
+end

--- a/lib/keycloak_ruby/testing/login_middleware.rb
+++ b/lib/keycloak_ruby/testing/login_middleware.rb
@@ -9,7 +9,7 @@ module KeycloakRuby
     # Используется хелпером sign_in для браузерных тестов (:feature/:system).
     #
     # Было:  visit /login → рендер HTML → клик → OmniAuth → SessionsController → редирект
-    # Стало: visit /__test_login__/123 → запись сессии → 204 No Content
+    # Стало: visit /__test_login__/123 → запись сессии → 200 OK
     class LoginMiddleware
       TEST_LOGIN_PATH = %r{\A/__test_login__/(\d+)\z}
 
@@ -29,6 +29,13 @@ module KeycloakRuby
 
       def handle_test_login(env, user_id)
         user = ::User.find(user_id)
+        fill_session(env, user)
+        [200, { "Content-Type" => "text/plain" }, ["Logged in"]]
+      rescue ActiveRecord::RecordNotFound
+        [404, { "Content-Type" => "text/plain" }, ["Test login failed: User #{user_id} not found"]]
+      end
+
+      def fill_session(env, user)
         email = user.email
         expired_time = 2.hours.from_now.to_i
         token_payload = { "email" => email, "exp" => expired_time }
@@ -37,8 +44,6 @@ module KeycloakRuby
         session[:access_token] = JWT.encode(token_payload, nil, "none")
         session[:refresh_token] = "fake-refresh-#{email}"
         session[:id_token] = "fake-id-#{email}"
-
-        [204, {}, []]
       end
     end
   end

--- a/lib/keycloak_ruby/testing/login_middleware.rb
+++ b/lib/keycloak_ruby/testing/login_middleware.rb
@@ -35,6 +35,7 @@ module KeycloakRuby
         [404, { "Content-Type" => "text/plain" }, ["Test login failed: User #{user_id} not found"]]
       end
 
+      # :reek:UtilityFunction
       def fill_session(env, user)
         email = user.email
         expired_time = 2.hours.from_now.to_i


### PR DESCRIPTION
### Добавлено

- Быстрый логин в тестах через Rack-middleware (`KeycloakRuby::Testing::LoginMiddleware`).
  В браузерных тестах (`:feature` / `:system`) `sign_in` теперь записывает фейковые токены
  прямо в сессию, минуя полный цикл OmniAuth. Это значительно ускоряет тесты,
  которые не проверяют сам логин.
- Хелпер `full_sign_in` — сохраняет прежнее поведение с полным проходом через OmniAuth.
  Для тестов, которые проверяют логин (flash-сообщения, редиректы и т.д.).
- `KeycloakRuby::Railtie` — автоматически подключает middleware
  в стек Rails только в test-окружении.

### Изменено

- **Breaking:** `sign_in` для тестов `:controller` / `:view` теперь использует
  `mock_token_service` (стабит `TokenService#find_user`) вместо настройки
  OmniAuth-мока и заполнения сессии токенами. Тесты, которые проверяют
  содержимое сессии, нужно перевести на `full_sign_in`.